### PR TITLE
Support BLS signing on Mac M1, as well

### DIFF
--- a/multiversx_sdk_wallet/libraries/bls_facade.py
+++ b/multiversx_sdk_wallet/libraries/bls_facade.py
@@ -88,11 +88,15 @@ class BLSFacade:
 
     def _get_library_path(self):
         os_name = platform.system()
+        processor = platform.processor()
 
         if os_name == "Windows":
             lib_name = "libbls.dll"
         elif os_name == "Darwin":
-            lib_name = "libbls.dylib"
+            if processor == "arm64":
+                lib_name = "libbls_arm64.dylib"
+            else:
+                lib_name = "libbls.dylib"
         elif os_name == "Linux":
             lib_name = "libbls.so"
         else:

--- a/multiversx_sdk_wallet/libraries/bls_facade.py
+++ b/multiversx_sdk_wallet/libraries/bls_facade.py
@@ -93,7 +93,7 @@ class BLSFacade:
         if os_name == "Windows":
             lib_name = "libbls.dll"
         elif os_name == "Darwin":
-            if processor == "arm64":
+            if processor == "arm":
                 lib_name = "libbls_arm64.dylib"
             else:
                 lib_name = "libbls.dylib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-wallet"
-version = "0.6.2"
+version = "0.7.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Related to: https://github.com/multiversx/mx-sdk-py-cli/issues/260

## For reviewers

We cannot currently build the library on GitHub Actions, thus we've built it on a **separate M1 machine**, from a branch of `sdk-go`:

https://github.com/multiversx/mx-sdk-go/pull/138

... which, in turn, references a branch of `mx-chain-crypto-go`:

https://github.com/multiversx/mx-chain-crypto-go/pull/24

Steps to compile the lib:

```
git clone https://github.com/multiversx/mx-sdk-go.git
cd mx-sdk-go
git checkout ref-crypto-m1
cd ./libraries/libbls
go build -buildmode=c-shared -o $HOME/libbls_arm64.dylib .
```

