### PR TITLE
Add extra check when decrypting secret key

### DIFF
--- a/multiversx_sdk_wallet/user_test.py
+++ b/multiversx_sdk_wallet/user_test.py
@@ -198,3 +198,11 @@ def test_load_secret_key_with_mnemonic():
     assert UserWallet.load_secret_key(keystore_path, "password", 1).generate_public_key().to_address("erd").to_bech32() == "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
     assert UserWallet.load_secret_key(keystore_path, "password", 2).generate_public_key().to_address("erd").to_bech32() == "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
     assert UserWallet.load_secret_key(keystore_path, "password", 0).generate_public_key().to_address("erd").to_bech32() == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+
+
+def test_decrypt_secret_key_with_keystore_mnemonic():
+    user_wallet = UserWallet.from_mnemonic(DUMMY_MNEMONIC, "")
+    mnemonic_json = user_wallet.to_dict()
+
+    with pytest.raises(Exception):
+        UserWallet.decrypt_secret_key(mnemonic_json, "")

--- a/multiversx_sdk_wallet/user_test.py
+++ b/multiversx_sdk_wallet/user_test.py
@@ -204,5 +204,5 @@ def test_decrypt_secret_key_with_keystore_mnemonic():
     user_wallet = UserWallet.from_mnemonic(DUMMY_MNEMONIC, "")
     mnemonic_json = user_wallet.to_dict()
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Expected kind to be secretKey, but it was mnemonic"):
         UserWallet.decrypt_secret_key(mnemonic_json, "")

--- a/multiversx_sdk_wallet/user_wallet.py
+++ b/multiversx_sdk_wallet/user_wallet.py
@@ -54,7 +54,10 @@ class UserWallet:
 
     @classmethod
     def decrypt_secret_key(cls, keyfile_object: Dict[str, Any], password: str) -> UserSecretKey:
-        # Here, we do not check the "kind" field. Older keystore files (holding only secret keys) do not have this field.
+        # Here, we check the "kind" field only for files that have it. Older keystore files (holding only secret keys) do not have this field.
+        kind = keyfile_object.get("kind", None)
+        if kind and kind != UserWalletKind.SECRET_KEY.value:
+            raise Exception(f"Expected kind to be {UserWalletKind.SECRET_KEY.value}, but it was {kind}")
 
         encrypted_data = EncryptedData.from_keyfile_object(keyfile_object)
         buffer = decryptor.decrypt(encrypted_data, password)

--- a/multiversx_sdk_wallet/user_wallet.py
+++ b/multiversx_sdk_wallet/user_wallet.py
@@ -34,7 +34,7 @@ class UserWallet:
         encrypted_data = encryptor.encrypt(data, password, randomness)
 
         return cls(
-            kind=UserWalletKind.SECRET_KEY,
+            kind=UserWalletKind.SECRET_KEY.value,
             encrypted_data=encrypted_data,
             public_key_when_kind_is_secret_key=public_key
         )
@@ -48,7 +48,7 @@ class UserWallet:
         encrypted_data = encryptor.encrypt(data, password, randomness)
 
         return cls(
-            kind=UserWalletKind.MNEMONIC,
+            kind=UserWalletKind.MNEMONIC.value,
             encrypted_data=encrypted_data
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-wallet"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Because there was no check for the `kind` field when calling `UserWallet.decrypt_secret_key()` one could have passed a `keystore-mnemonic` file. There is still a limitation for older files that do not contain that field.

Fixes issue https://github.com/multiversx/mx-sdk-py-cli/issues/350.